### PR TITLE
Fix for Issue 14005

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
-*.local.*
+__pycache__
 *.ckpt
 *.safetensors
 *.pth
 /ESRGAN/*
 /SwinIR/*
 /repositories
+/venv
+/test-venv
 /tmp
 /model.ckpt
 /models/**/*
@@ -37,110 +39,8 @@ notification.mp3
 /package-lock.json
 /.coverage*
 
-# ignore files only in root of repo which are version numbers
+# ignore files root of repo which are version numbers
 /*.*.*
 
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
+# ignore files which are "local" edits of webui-*.bat, etc.
+*.local.bat

--- a/modules/styles.py
+++ b/modules/styles.py
@@ -61,7 +61,14 @@ def unwrap_style_text_from_prompt(style_text, prompt):
     if "{prompt}" in stripped_style_text:
         # Work out whether the prompt is wrapped in the style text. If so, we
         # return True and the "inner" prompt text that isn't part of the style.
-        left, right = stripped_style_text.split("{prompt}", 2)
+        try:
+            left, right = stripped_style_text.split("{prompt}", 2)
+        except ValueError as e:
+            # If the style text has multple "{prompt}"s, we can't split it into
+            # two parts. This is an error, but we can't do anything about it.
+            print("Unable to compare style text to prompt:`n{style_text}")
+            print(f"Error: {e}")
+            return False, prompt
         if stripped_prompt.startswith(left) and stripped_prompt.endswith(right):
             prompt = stripped_prompt[len(left) : len(stripped_prompt) - len(right)]
             return True, prompt


### PR DESCRIPTION
## Description

* Error handling for cases where a style contains `{prompt}` more than once and cannot be split into two parts (before- and after- the prompt)
* A try-except wrapped around the line that splits the style text, with a warning printed to the console
* [Issue 14005](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14005)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
